### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS build
 LABEL maintainer="otiai10 <otiai10@gmail.com>"
-
-ARG LOAD_LANG=jpn
 
 RUN apt update \
     && apt install -y \
@@ -11,6 +9,7 @@ RUN apt update \
       golang=2:1.15~1
 
 ENV GO111MODULE=on
+ENV GOPROXY="https://goproxy.cn,direct"
 ENV GOPATH=${HOME}/go
 ENV PATH=${PATH}:${GOPATH}/bin
 
@@ -19,7 +18,12 @@ WORKDIR $GOPATH/src/github.com/otiai10/ocrserver
 RUN go get -v ./... && go install .
 
 # Load languages
+ARG LOAD_LANG=chi-sim
 RUN if [ -n "${LOAD_LANG}" ]; then apt-get install -y tesseract-ocr-${LOAD_LANG}; fi
 
 ENV PORT=8080
-CMD ["ocrserver"]
+
+FROM scratch AS OS
+
+COPY --from=build /go/bin/ocrserver /
+CMD [ "/ocrserver" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,74 @@
-FROM debian:bullseye-slim AS build
-LABEL maintainer="otiai10 <otiai10@gmail.com>"
+# make base image.
+FROM debian:bullseye-slim AS base
+LABEL maintainer="otiai10 <otiai10@gmail.com>" \
+	updatedBy="RocSun <oldsixa@163.com>"
 
-RUN apt update \
-    && apt install -y \
-      ca-certificates \
-      libtesseract-dev=4.1.1-2.1 \
-      tesseract-ocr=4.1.1-2.1 \
-      golang=2:1.15~1
+RUN apt-get update \
+    && apt-get install -y ca-certificates \
+      apt-transport-https \
+    # this setting local apt mirrors
+    && cp -a /etc/apt/sources.list /etc/apt/sources.list.bak \ 
+    && sed -i "s@http://deb.debian.org@https://repo.huaweicloud.com@g" /etc/apt/sources.list \
+    && sed -i "s@http://security.debian.org@https://repo.huaweicloud.com@g" /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y libtesseract-dev=4.1.1-2.1 \
+      tesseract-ocr=4.1.1-2.1
+
+# build source.
+FROM base AS build
+
+RUN apt install -y golang=2:1.15~1
 
 ENV GO111MODULE=on
 ENV GOPROXY="https://goproxy.cn,direct"
-ENV GOPATH=${HOME}/go
+ENV GOPATH=/go
 ENV PATH=${PATH}:${GOPATH}/bin
 
-ADD . $GOPATH/src/github.com/otiai10/ocrserver
-WORKDIR $GOPATH/src/github.com/otiai10/ocrserver
+ADD . $GOPATH/src/ocrserver
+WORKDIR $GOPATH/src/ocrserver
 RUN go get -v ./... && go install .
 
-# Load languages
-ARG LOAD_LANG=chi-sim
-RUN if [ -n "${LOAD_LANG}" ]; then apt-get install -y tesseract-ocr-${LOAD_LANG}; fi
-
+# make run env. This is build image.
+FROM base AS OS
 ENV PORT=8080
+COPY --from=build /go /go
 
-FROM scratch AS OS
+ARG LOAD_LANG=chi-sim
+RUN if [ -n "${LOAD_LANG}" ]; then apt-get install -y tesseract-ocr-${LOAD_LANG}; fi \
+    && apt-get clean
+CMD [ "/go/bin/ocrserver" ]
 
-COPY --from=build /go/bin/ocrserver /
-CMD [ "/ocrserver" ]
+# ################################################################################
+# # debian:bullseye-slim image size of is about 220M.                            #
+# # if use alpine. image size of is about 160M. Here's the alpine-based code     #
+# # min image in dockerhub rocsun/ocr-server                                     #
+# ################################################################################
+
+# FROM alpine:3.14 as base
+#LABEL maintainer="otiai10 <otiai10@gmail.com>" \
+# 	 updatedBy="RocSun <oldsixa@163.com>"
+
+# RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories \
+#     && apk add tesseract-ocr \
+#     && apk add tesseract-ocr-dev \
+#     && apk add tesseract-ocr-data-chi_sim
+
+# FROM base AS build
+
+# RUN apk add go \
+#       g++
+
+# ENV GO111MODULE=on
+# ENV GOPROXY="https://goproxy.cn,direct"
+# ENV GOPATH=/go
+# ENV PATH=${PATH}:${GOPATH}/bin
+
+# ADD . $GOPATH/src/ocrserver
+# WORKDIR $GOPATH/src/ocrserver
+# RUN go get -v ./... && go install .
+
+# FROM base AS OS
+# RUN apk add bash
+# COPY --from=build /go /go
+# ENV PORT=8080
+# CMD ["/go/bin/ocrserver"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,16 @@
 version: "3.7"
 services:
-  web:
-    build:
+  ocr-web:
+    build: 
       context: .
-    # dockerfile: Dockerfile
+      dockerfile: Dockerfile
     ports:
       - "8080:8080"
     environment:
       PORT: 8080
+    # container_name: ocr-server
+    # command: 
+    #   - /bin/bash
+    #   - -c
+    #   - |
+    #     /go/bin/ocrserver


### PR DESCRIPTION
## Optimize Dockerfile.

Optimize Dockerfile. Old dockerfile build image size is about 800+M,this docker file build image size is about 200M, if use alpine base image, build image size is about 160M, and test pass.
dockerhub repositories at redsun/ocr-server.
